### PR TITLE
Add ability to set rsync options with an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,14 @@ Automatically rsync files to a remote server if any of them are changed.
 
     autorsync . 192.168.1.127:/var/www
 
-Same as above, but don't copy .pyc files.
+The above invokes `rsync` with `-avz` (archive mode, verbose, compress). To 
+pass additional arguments to `rsync`, for example:
 
-    notifyloop ~/code/directory rsync -avz --exclude="*.pyc" ~/code/directory/ server.example.com:/stuff/
+    RSYNC_OPTS='--exclude="*.pyc"' autorsync . 192.168.1.127:/var/www
+
+To do the same thing "manually":
+
+    notifyloop . rsync -avz --exclude="*.pyc" . 192.168.1.127:/var/www
 
 
 ## Building from source

--- a/autorsync
+++ b/autorsync
@@ -9,5 +9,6 @@ fi
 WATCH_PATH="$1"
 shift
 DEST=("$@")
+rsync_opts=( $RSYNC_OPTS )
 
-notifyloop "$WATCH_PATH" rsync -avz "$WATCH_PATH" "${DEST[@]}"
+notifyloop "$WATCH_PATH" rsync -avz "${rsync_opts[@]}" "$WATCH_PATH" "${DEST[@]}"


### PR DESCRIPTION
This makes using autorsync a little bit more convenient, I think.

I notice that the shebang line is `/bin/sh`, and this uses arrays, which are not part of the Bourne shell. My mac uses bash for /bin/sh, and I have no idea how common that is, so if you don't want to pull this for that reason, no problem.
